### PR TITLE
Add root AGENTS.md pointer and `hai-harness update` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS
+
+This project uses [HAI-Harness](https://github.com/ClaudiusMa/HAI-Harness), a repo-as-truth collaboration layer for humans and AI agents.
+
+## Where to look
+
+- `Agents/` — the agent operating layer. Shared execution context, role definitions, planner state, task contracts, handoffs, and lessons. **This is your scope.**
+- `Human/` — the human workspace (product thinking, decisions, open questions). **Do not read `Human/` unless the user explicitly instructs it.**
+
+## Start here
+
+Before doing anything else, read [`Agents/onboarding.md`](Agents/onboarding.md). It defines:
+
+- the file graph and what each file means,
+- the active role you are in (Claudia, Augustus, or Julius) and its required read order,
+- the rules of collaboration that you must follow for the rest of the session.
+
+If the user has not told you which role you are in, ask before proceeding.
+
+## Operating rules (summary)
+
+- The repo is the only source of truth. Do not act on chat history or assumed memory.
+- One role per chat session. No role switching mid-session.
+- Cross-role collaboration happens through `Agents/planning.md`, task docs, and handoff notes — never through chat history.
+- Do not move from clarification into implementation planning without an explicit user check-in.
+- Do not run high-cost behavior without an explicit user check-in.
+
+The full rules live in [`Agents/onboarding.md`](Agents/onboarding.md). Read it now.

--- a/README.md
+++ b/README.md
@@ -48,42 +48,67 @@ We have built the foundational architecture for memory, context isolation, and t
 
 ## Installing HAI-Harness Into An Existing Project
 
-HAI-Harness is designed to be installed as a repository overlay. It does not replace your app structure and it is not a runtime dependency for your product code. It adds the `Agents/` and `Human/` collaboration layer alongside the project files you already have.
+HAI-Harness is a repository overlay, not a runtime dependency. It adds the `Agents/` and `Human/` collaboration layer (plus a root `AGENTS.md` pointer for AI tools) alongside the project files you already have. It does not replace your app structure.
 
-From an existing project:
+### First-time install
+
+From inside an existing project:
 
 ```sh
 cd your-existing-project
 npx hai-harness init
 ```
 
-The short `npx hai-harness init` command works after the package is published to npm. Before npm publishing, you can run the CLI from this repository directly:
-
-```sh
-cd your-existing-project
-node ../HAI-Harness/bin/hai-harness.mjs init
-```
-
-Or, once this repository is available on GitHub with package metadata, you can run it through `npx` without publishing to npm:
+The short `npx hai-harness init` form works once the package is published to npm. Until then, install directly from GitHub:
 
 ```sh
 cd your-existing-project
 npx github:ClaudiusMa/HAI-Harness init
 ```
 
-The installer is conservative by default. It creates missing harness files and skips files that already exist:
+Or, if you have this repo cloned locally:
+
+```sh
+cd your-existing-project
+node ../HAI-Harness/bin/hai-harness.mjs init
+```
+
+The installer is conservative — it creates missing harness files and skips files that already exist. Use `--dry-run` to preview, `--force` to overwrite:
 
 ```sh
 npx hai-harness init --dry-run
 npx hai-harness init --force
+```
+
+After install you'll have:
+
+- `AGENTS.md` at the project root — the entry point any AI agent reads first. It points the agent at `Agents/onboarding.md` and explicitly tells it not to read `Human/`.
+- `Agents/` — the agent operating layer.
+- `Human/` — your private workspace for product thinking.
+
+You can verify the install at any time:
+
+```sh
 npx hai-harness doctor
 ```
 
-After installation, start new agent sessions by pointing them at the harness:
+### Pulling the latest harness changes
 
-```txt
-Read Agents/onboarding.md first and operate through the HAI-Harness.
+HAI-Harness evolves. To pull in the latest role definitions and onboarding files without touching your project-specific content:
+
+```sh
+npx hai-harness update
 ```
+
+`update` only refreshes the stable scaffold (role docs, onboarding files, `AGENTS.md`). It **never** overwrites your project-specific files: `brief.md`, `decisions.md`, `open_questions.md`, `reflections.md`, `project_context.md`, `planning.md`, `tasks/`, `handoffs/`, `lessons/`, `patterns.md`, `graveyard.md`, `_archive/`, `skills/`.
+
+If you want a full reset (overwrite everything from the latest version), use:
+
+```sh
+npx hai-harness init --force
+```
+
+Preview either command with `--dry-run` first.
 
 ## How to Operate the Harness (The User Guide)
 

--- a/bin/hai-harness.mjs
+++ b/bin/hai-harness.mjs
@@ -7,22 +7,41 @@ import { fileURLToPath } from "node:url";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const templateDirs = ["Agents", "Human"];
+const templateFiles = ["AGENTS.md"];
 const ignoredNames = new Set([".DS_Store"]);
+
+// Scaffold files are the stable, method-level docs that define how the harness
+// works. `update` refreshes them in place. Project-specific content
+// (project_context.md, planning.md, anything under Human/, tasks/, handoffs/,
+// lessons/, _archive/, skills/, patterns.md, graveyard.md) is never touched
+// by `update` — use `init --force` for a full reset.
+const scaffoldPaths = [
+  "AGENTS.md",
+  "Agents/onboarding.md",
+  "Agents/claudia.md",
+  "Agents/augustus.md",
+  "Agents/julius.md",
+  "Human/onboarding.md"
+];
 
 const usage = `HAI-Harness
 
 Usage:
-  hai-harness init [--target <dir>] [--force] [--dry-run]
-  hai-harness doctor [--target <dir>]
+  hai-harness init    [--target <dir>] [--force] [--dry-run]
+  hai-harness update  [--target <dir>] [--dry-run]
+  hai-harness doctor  [--target <dir>]
   hai-harness help
 
 Commands:
   init     Copy the HAI-Harness files into an existing project.
+  update   Refresh only the stable scaffold files (role docs, onboarding, AGENTS.md).
+           Leaves project-specific files (brief.md, decisions.md, project_context.md,
+           planning.md, tasks/, handoffs/, lessons/, etc.) untouched.
   doctor   Check whether the target project has the expected harness files.
 
 Options:
   --target <dir>  Project directory to operate on. Defaults to the current directory.
-  --force         Overwrite existing harness files.
+  --force         (init only) Overwrite existing harness files.
   --dry-run       Show what would change without writing files.
 `;
 
@@ -42,6 +61,11 @@ async function main() {
 
   if (command === "init") {
     await init(options);
+    return;
+  }
+
+  if (command === "update") {
+    await update(options);
     return;
   }
 
@@ -99,7 +123,49 @@ async function init(options) {
     await copyDirectory(sourceDir, targetDir, options, results);
   }
 
+  for (const file of templateFiles) {
+    const sourcePath = path.join(packageRoot, file);
+    const targetPath = path.join(target, file);
+    await copyFile(sourcePath, targetPath, options, results);
+  }
+
   printInitSummary(target, options, results);
+}
+
+async function update(options) {
+  const target = options.target;
+  await assertDirectory(target);
+
+  const results = {
+    updated: [],
+    created: [],
+    missingSource: []
+  };
+
+  for (const relativePath of scaffoldPaths) {
+    const sourcePath = path.join(packageRoot, relativePath);
+    const targetPath = path.join(target, relativePath);
+
+    if (!(await exists(sourcePath))) {
+      results.missingSource.push(relativePath);
+      continue;
+    }
+
+    const targetExists = await exists(targetPath);
+
+    if (!options.dryRun) {
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.copyFile(sourcePath, targetPath);
+    }
+
+    if (targetExists) {
+      results.updated.push(relativePath);
+    } else {
+      results.created.push(relativePath);
+    }
+  }
+
+  printUpdateSummary(target, options, results);
 }
 
 async function doctor(options) {
@@ -107,6 +173,7 @@ async function doctor(options) {
   await assertDirectory(target);
 
   const requiredPaths = [
+    "AGENTS.md",
     "Agents/onboarding.md",
     "Agents/project_context.md",
     "Agents/planning.md",
@@ -136,6 +203,31 @@ async function doctor(options) {
     console.log(`  - ${relativePath}`);
   }
   process.exitCode = 1;
+}
+
+async function copyFile(sourcePath, targetPath, options, results) {
+  if (!(await exists(sourcePath))) {
+    return;
+  }
+
+  const relativePath = path.relative(options.target, targetPath);
+  const targetExists = await exists(targetPath);
+
+  if (targetExists && !options.force) {
+    results.skipped.push(relativePath);
+    return;
+  }
+
+  if (!options.dryRun) {
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    await fs.copyFile(sourcePath, targetPath);
+  }
+
+  if (targetExists) {
+    results.overwritten.push(relativePath);
+  } else {
+    results.created.push(relativePath);
+  }
 }
 
 async function copyDirectory(sourceDir, targetDir, options, results) {
@@ -217,6 +309,20 @@ function printInitSummary(target, options, results) {
     console.log("");
     console.log("Existing files were left unchanged. Re-run with --force to overwrite harness files.");
   }
+}
+
+function printUpdateSummary(target, options, results) {
+  const mode = options.dryRun ? "Dry run complete" : "HAI-Harness scaffold updated";
+  console.log(`${mode} for ${target}`);
+  console.log("");
+  printCount("Updated", results.updated);
+  printCount("Created", results.created);
+  if (results.missingSource.length > 0) {
+    printCount("Missing in package (skipped)", results.missingSource);
+  }
+  console.log("");
+  console.log("Project-specific files (brief.md, decisions.md, project_context.md, planning.md, tasks/, handoffs/, lessons/, etc.) were left untouched.");
+  console.log("Run `hai-harness init --force` if you want to overwrite everything.");
 }
 
 function printCount(label, paths) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "Agents",
     "Human",
     "bin",
+    "AGENTS.md",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Two installer gaps surfaced when using HAI-Harness in a real project:

1. After `init`, AI agents had no breadcrumb at the project root telling them this repo uses the harness or where to look. They never read `Agents/onboarding.md` unless the user remembered to point them at it in every new session. Fix: ship `AGENTS.md` at the project root. It names the harness, scopes the agent to `Agents/`, marks `Human/` as off-limits by default, and routes to `Agents/onboarding.md` as the required first read. `init` copies it, `doctor` checks for it, and `package.json` ships it in the npm tarball.

2. The README explained how to install but not how to pull later harness changes. `init --force` would clobber a user's `brief.md`, `decisions.md`, `project_context.md`, and `planning.md` — the files that hold all the project-specific thinking. Fix: add a new `hai-harness update` command that refreshes only the stable scaffold (AGENTS.md, role docs, onboarding files) and leaves every project-specific file untouched. README "Installing" section is rewritten to be user-facing and includes a "Pulling the latest harness changes" subsection covering `update` vs `init --force`.